### PR TITLE
add-github-templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,18 @@
+# Story
+
+# Acceptance Criteria
+
+- [ ]
+
+# Screenshots / Video
+
+<details>
+<summary></summary>
+
+</details>
+
+# Testing Instructions and Sample Files
+
+-
+
+# Notes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+# Story
+
+Refs
+
+- #issuenumber
+
+# Expected Behavior Before Changes
+
+# Expected Behavior After Changes
+
+# Screenshots / Video
+
+<details>
+<summary></summary>
+
+</details>
+
+# Notes


### PR DESCRIPTION
add github issue templates

refs https://github.com/scientist-softserv/dev-ops/issues/631.

Now that we've moved to Github, we're adding issue and PR templates to standardize these processes across all repos.