### PR TITLE
testing-deploy-env-vars

### DIFF
--- a/.github/workflows/build-lint-test.yaml
+++ b/.github/workflows/build-lint-test.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build:
-    uses: scientist-softserv/actions/.github/workflows/build.yaml@v0.0.14
+    uses: scientist-softserv/actions/.github/workflows/build.yaml@testing-deploy-env-vars
     secrets: inherit
     with:
       platforms: 'linux/amd64'
@@ -26,7 +26,7 @@ jobs:
       solrTarget: solr
   test:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.14
+    uses: scientist-softserv/actions/.github/workflows/test.yaml@testing-deploy-env-vars
     with:
       confdir: '/home/app/webapp/solr/conf'
       webTarget: web
@@ -37,7 +37,7 @@ jobs:
       rspec_cmd: 'bundle exec rspec'
   lint:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.14
+    uses: scientist-softserv/actions/.github/workflows/lint.yaml@testing-deploy-env-vars
     with:
       webTarget: web
       workerTarget: worker

--- a/.github/workflows/build-lint-test.yaml
+++ b/.github/workflows/build-lint-test.yaml
@@ -33,7 +33,7 @@ jobs:
       workerTarget: worker
       solrTarget: solr
       setup_solr_cmd: ''
-      setup_db_cmd: 'RAILS_ENV=test PASSENGER_APP_ENV=test bundle exec rails db:create db:migrate db:test:prepare'
+      setup_db_cmd: ''
       rspec_cmd: 'bundle exec rspec'
   lint:
     needs: build

--- a/.github/workflows/build-lint-test.yaml
+++ b/.github/workflows/build-lint-test.yaml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build:
-    uses: scientist-softserv/actions/.github/workflows/build.yaml@testing-deploy-env-vars
+    uses: scientist-softserv/actions/.github/workflows/build.yaml@v0.0.14
     secrets: inherit
     with:
       platforms: 'linux/amd64'
@@ -26,7 +26,7 @@ jobs:
       solrTarget: solr
   test:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/test.yaml@testing-deploy-env-vars
+    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.14
     with:
       confdir: '/home/app/webapp/solr/conf'
       webTarget: web
@@ -37,7 +37,7 @@ jobs:
       rspec_cmd: 'bundle exec rspec'
   lint:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/lint.yaml@testing-deploy-env-vars
+    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.14
     with:
       webTarget: web
       workerTarget: worker

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   deploy:
-    uses: scientist-softserv/actions/.github/workflows/deploy.yaml@v0.0.14
+    uses: scientist-softserv/actions/.github/workflows/deploy.yaml@testing-deploy-env-vars
     secrets: inherit
     with:
       deploy-solr-image: true

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   deploy:
-    uses: scientist-softserv/actions/.github/workflows/deploy.yaml@testing-deploy-env-vars
+    uses: scientist-softserv/actions/.github/workflows/deploy.yaml@v0.0.14
     secrets: inherit
     with:
       deploy-solr-image: true

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@
 public/packs/*
 .DS_Store
 .env.*
-.env.*
+*-deploy.yaml
 /public/uv
 
 # Ignore local development history

--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -17,8 +17,8 @@ environment=${release_name#*-}
 deploy_file="${environment}-deploy"
 
 ENV_FILE="./.env.${environment}"
-ENCRYPTED_ENV_FILE="./.env.${environment}.enc"
-DECRYPTED_ENV_FILE="./.env.${environment}.dec"
+ENCRYPTED_ENV_FILE=".env.${environment}.enc"
+DECRYPTED_ENV_FILE=".env.${environment}.dec"
 
 # FOR LOCAL DEPLOY
 # run ./bin/helm_deploy RELEASE_NAME NAMESPACE
@@ -26,8 +26,8 @@ DECRYPTED_ENV_FILE="./.env.${environment}.dec"
 # .env.${environment} file locally or in 1Password
 if [ -f "$ENV_FILE" ]; then
   # remove our previous tests
-  rm -rf "./.env.${environment}.enc"
-  rm -rf "./.env.${environment}.dec"
+  rm -rf ".env.${environment}.enc"
+  rm -rf ".env.${environment}.dec"
   rm -rf "ops/${deploy_file}.yaml"
 
   cat "$ENV_FILE" | base64 > "$ENCRYPTED_ENV_FILE"
@@ -42,6 +42,7 @@ else
   # file to your project you can then get the ENCRYPTED_ENV_FILE
   # value by running: cat "$ENV_FILE" | base64 > "$ENCRYPTED_ENV_FILE",
   # in your terminal locally to get the value needed to set in GitHub
+  touch "$DECRYPTED_ENV_FILE"
   echo "$ENCRYPTED_ENV_FILE" | base64 -d > "$DECRYPTED_ENV_FILE"
 fi
 
@@ -57,6 +58,8 @@ helm upgrade \
     --install \
     --atomic \
     --timeout 15m0s \
+    --dry-run \
+    --debug \
     --set rails.image.repository="$DEPLOY_IMAGE" \
     --set rails.image.tag="$DEPLOY_TAG" \
     --set solr.image.repository="$SOLR_IMAGE" \

--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -17,11 +17,6 @@ environment=${release_name#*-}
 deploy_file="${environment}-deploy"
 
 ENV_FILE="./.env.${environment}"
-ENCRYPTED_ENV_FILE=".env.${environment}.enc"
-# DECRYPTED_ENV_FILE=".env.${environment}.dec"
-# if there is not a env file like in ci
-# create the file and then echo the
-# ENCRYPTED_ENV_FILE and shovel it into the file
 
 if [ ! -f "$ENV_FILE" ]; then
   # if there is not an env.staging file
@@ -30,14 +25,14 @@ if [ ! -f "$ENV_FILE" ]; then
   # cat the ENCRYPTED_ENV_FILE value set in github
   # and decrypt & it and shovel it into the ENV_FILE
   cat "$ENCRYPTED_ENV_FILE" | base64 -d > "./.env.${environment}"
+  # now we have an unencrypted env file
+else
+  # there is already an env file locally
+  # set the helm extra args for local
+  HELM_EXTRA_ARGS="--values ops/${deploy_file}.yaml"
+  DEPLOY_TAG=Set_me_with_ghcr_sha
+  DRY_RUN_DEBUG="--dry-run --debug"
 fi
-
-# cat "$ENCRYPTED_ENV_FILE" | base64 -d > "$DECRYPTED_ENV_FILE"
-
-HELM_EXTRA_ARGS="--values ops/${deploy_file}.yaml"
-# DEPLOY_TAG= <------------------------------- SET DEPLOY TAG
-DRY_RUN_DEBUG="--dry-run --debug"
-
 
 # Take the env file and export each key value pair
 # so we can use it with envsubst in our deploy

--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -24,7 +24,8 @@ if [ ! -f "$ENV_FILE" ]; then
   touch "./.env.${environment}"
   # cat the ENCRYPTED_ENV_FILE value set in github
   # and decrypt & it and shovel it into the ENV_FILE
-  cat "$ENCRYPTED_ENV_FILE" | base64 -d > "./.env.${environment}"
+  # cat "$ENCRYPTED_ENV_FILE" | base64 -d > "./.env.${environment}"
+  echo "$ENCRYPTED_ENV_FILE" | base64 -d > "./.env.${environment}"
   # now we have an unencrypted env file
 else
   # there is already an env file locally

--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -12,27 +12,18 @@ DEPLOY_IMAGE="${DEPLOY_IMAGE:-ghcr.io/scientist-softserv/arce}"
 SOLR_IMAGE="${SOLR_IMAGE:-ghcr.io/scientist-softserv/arce/solr}"
 DEPLOY_TAG="${DEPLOY_TAG:-latest}"
 
-# Extracting the environment value after "-"
 environment=${release_name#*-}
 deploy_file="${environment}-deploy"
 
 ENV_FILE="./.env.${environment}"
 
 if [ ! -f "$ENV_FILE" ]; then
-  # if there is not an env.staging file
-  # create the blank file
   touch "./.env.${environment}"
-  # cat the ENCRYPTED_ENV_FILE value set in github
-  # and decrypt & it and shovel it into the ENV_FILE
-  # cat "$ENCRYPTED_ENV_FILE" | base64 -d > "./.env.${environment}"
   echo "$ENCRYPTED_ENV_FILE" | base64 -d > "./.env.${environment}"
-  # now we have an unencrypted env file
 else
-  # there is already an env file locally
-  # set the helm extra args for local
   HELM_EXTRA_ARGS="--values ops/${deploy_file}.yaml"
-  DEPLOY_TAG=Set_me_with_ghcr_sha
-  DRY_RUN_DEBUG="--dry-run --debug"
+  # DEPLOY_TAG=Set_me_with_ghcr_sha
+  # DRY_RUN_DEBUG="--dry-run --debug"
 fi
 
 # Take the env file and export each key value pair

--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -42,7 +42,7 @@ else
   # file to your project you can then get the ENCRYPTED_ENV_FILE
   # value by running: cat "$ENV_FILE" | base64 > "$ENCRYPTED_ENV_FILE",
   # in your terminal locally to get the value needed to set in GitHub
-  cat "$ENCRYPTED_ENV_FILE" | base64 -d > "$DECRYPTED_ENV_FILE"
+  echo "$ENCRYPTED_ENV_FILE" | base64 -d > "$DECRYPTED_ENV_FILE"
 fi
 
 # Take the env file and export each key value pair

--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -19,7 +19,6 @@ deploy_file="${environment}-deploy"
 ENV_FILE="./.env.${environment}"
 ENCRYPTED_ENV_FILE=".env.${environment}.enc"
 DECRYPTED_ENV_FILE=".env.${environment}.dec"
-
 # FOR LOCAL DEPLOY
 # run ./bin/helm_deploy RELEASE_NAME NAMESPACE
 # If we are deploying locally we will have the
@@ -42,7 +41,8 @@ else
   # file to your project you can then get the ENCRYPTED_ENV_FILE
   # value by running: cat "$ENV_FILE" | base64 > "$ENCRYPTED_ENV_FILE",
   # in your terminal locally to get the value needed to set in GitHub
-  echo "$ENCRYPTED_ENV_FILE" | base64 -d > .env.${environment}.dec
+  echo "$ENCRYPTED_ENV_FILE" > ".env.${environment}.enc"
+  cat "$ENCRYPTED_ENV_FILE" | base64 -d > ".env.${environment}.dec"
 fi
 
 # Take the env file and export each key value pair

--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -30,7 +30,6 @@ fi
 # so we can use it with envsubst in our deploy
 while IFS='=' read -r key value; do
   export "$key=${value//\"/}"
-  echo "$key=${value//\"/}"
 done < <(grep -v '^#' "$ENV_FILE")
 
 DOLLAR=$ envsubst <"ops/${deploy_file}.tmpl.yaml" >"ops/${deploy_file}.yaml"

--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -37,20 +37,19 @@ if [ -f "$ENV_FILE" ]; then
   # DEPLOY_TAG= <-------------------------------------- SET ME
 else
   # FOR GitHub ACTIONS DEPLOY
-  # Set ENCRYPTED_ENV_FILE in GitHub Environment Secret
+  # Set ENCRYPTED_ENV_FILE in GitHub environment variable
   # section of project repo after copying the .env.${environment}
   # file to your project you can then get the ENCRYPTED_ENV_FILE
   # value by running: cat "$ENV_FILE" | base64 > "$ENCRYPTED_ENV_FILE",
   # in your terminal locally to get the value needed to set in GitHub
-  touch "$DECRYPTED_ENV_FILE"
-  echo "$ENCRYPTED_ENV_FILE" | base64 -d > "$DECRYPTED_ENV_FILE"
+  echo "$ENCRYPTED_ENV_FILE" | base64 -d > .env.${environment}.dec
 fi
 
 # Take the env file and export each key value pair
 # so we can use it with envsubst in our deploy
 while IFS='=' read -r key value; do
   export "$key=${value//\"/}"
-done < <(grep -v '^#' "$DECRYPTED_ENV_FILE")
+done < <(grep -v '^#' ".env.${environment}.dec")
 
 DOLLAR=$ envsubst <"ops/${deploy_file}.tmpl.yaml" >"ops/${deploy_file}.yaml"
 

--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -20,7 +20,10 @@ ENV_FILE="./.env.${environment}"
 ENCRYPTED_ENV_FILE="./.env.${environment}.enc"
 DECRYPTED_ENV_FILE="./.env.${environment}.dec"
 
+if [ -f "$ENV_FILE" ]; then
 cat "$ENV_FILE" | base64 > "$ENCRYPTED_ENV_FILE"
+fi
+
 cat "$ENCRYPTED_ENV_FILE" | base64 -d > "$DECRYPTED_ENV_FILE"
 
 while IFS='=' read -r key value; do

--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -18,36 +18,33 @@ deploy_file="${environment}-deploy"
 
 ENV_FILE="./.env.${environment}"
 ENCRYPTED_ENV_FILE=".env.${environment}.enc"
-DECRYPTED_ENV_FILE=".env.${environment}.dec"
+# DECRYPTED_ENV_FILE=".env.${environment}.dec"
+# if there is not a env file like in ci
+# create the file and then echo the
+# ENCRYPTED_ENV_FILE and shovel it into the file
 
-# FOR LOCAL DEPLOY
-# run ./bin/helm_deploy RELEASE_NAME NAMESPACE
-# If we are deploying locally we will have the
-# .env.${environment} file locally or in 1Password
-if [ -f "$ENV_FILE" ]; then
-
-  cat "$ENV_FILE" | base64 > "$ENCRYPTED_ENV_FILE"
-  cat "$ENCRYPTED_ENV_FILE" | base64 -d > "$DECRYPTED_ENV_FILE"
-
-  HELM_EXTRA_ARGS="--values ops/${deploy_file}.yaml"
-  # DEPLOY_TAG= <------------------------------- SET DEPLOY TAG
-  # DRY_RUN_DEBUG="--dry-run --debug" <--------- UNCOMMENT TO ENABLE
-else
-  # FOR GitHub ACTIONS DEPLOY
-  # Set ENCRYPTED_ENV_FILE in GitHub environment variable
-  # section of project repo after copying the .env.${environment}
-  # file to your project you can then get the ENCRYPTED_ENV_FILE
-  # value by running: cat "$ENV_FILE" | base64 > "$ENCRYPTED_ENV_FILE",
-  # in your terminal locally to get the value needed to set in GitHub
-  # echo "$ENCRYPTED_ENV_FILE" > ".env.${environment}.enc"
-  echo "$ENCRYPTED_ENV_FILE" | base64 -d > "$DECRYPTED_ENV_FILE"
+if [ ! -f "$ENV_FILE" ]; then
+  # if there is not an env.staging file
+  # create the blank file
+  touch "./.env.${environment}"
+  # cat the ENCRYPTED_ENV_FILE value set in github
+  # and decrypt & it and shovel it into the ENV_FILE
+  cat "$ENCRYPTED_ENV_FILE" | base64 -d > "./.env.${environment}"
 fi
+
+# cat "$ENCRYPTED_ENV_FILE" | base64 -d > "$DECRYPTED_ENV_FILE"
+
+HELM_EXTRA_ARGS="--values ops/${deploy_file}.yaml"
+# DEPLOY_TAG= <------------------------------- SET DEPLOY TAG
+DRY_RUN_DEBUG="--dry-run --debug"
+
 
 # Take the env file and export each key value pair
 # so we can use it with envsubst in our deploy
 while IFS='=' read -r key value; do
   export "$key=${value//\"/}"
-done < <(grep -v '^#' "$DECRYPTED_ENV_FILE")
+  echo "$key=${value//\"/}"
+done < <(grep -v '^#' "$ENV_FILE")
 
 DOLLAR=$ envsubst <"ops/${deploy_file}.tmpl.yaml" >"ops/${deploy_file}.yaml"
 

--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -39,8 +39,6 @@ helm upgrade \
     --install \
     --atomic \
     --timeout 15m0s \
-    --dry-run \
-    --debug \
     --set rails.image.repository="$DEPLOY_IMAGE" \
     --set rails.image.tag="$DEPLOY_TAG" \
     --set solr.image.repository="$SOLR_IMAGE" \

--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -5,13 +5,24 @@ then
     echo './bin/helm_deploy RELEASE_NAME NAMESPACE'
     exit 1
 fi
-
 release_name="${1}"
 namespace="${2}"
 
 DEPLOY_IMAGE="${DEPLOY_IMAGE:-ghcr.io/scientist-softserv/arce}"
 SOLR_IMAGE="${SOLR_IMAGE:-ghcr.io/scientist-softserv/arce/solr}"
+
 DEPLOY_TAG="${DEPLOY_TAG:-latest}"
+
+environment=${release_name#*-}  # Extracting the environment value after "-"
+deploy_file="${environment}-deploy"
+ENVCONFIG="./.env.${environment}"
+
+echo $KUBECONFIG_FILE | base64 -d > $KUBECONFIG;
+echo $ENVCONFIG_FILE | base64 -d > $ENVCONFIG;
+
+if [[ -n $environment ]]; then
+    DOLLAR=$ envsubst <"ops/${deploy_file}.tmpl.yaml" >"ops/${deploy_file}.yaml"
+fi
 
 helm upgrade \
     --install \

--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -19,21 +19,19 @@ deploy_file="${environment}-deploy"
 ENV_FILE="./.env.${environment}"
 ENCRYPTED_ENV_FILE=".env.${environment}.enc"
 DECRYPTED_ENV_FILE=".env.${environment}.dec"
+
 # FOR LOCAL DEPLOY
 # run ./bin/helm_deploy RELEASE_NAME NAMESPACE
 # If we are deploying locally we will have the
 # .env.${environment} file locally or in 1Password
 if [ -f "$ENV_FILE" ]; then
-  # remove our previous tests
-  rm -rf ".env.${environment}.enc"
-  rm -rf ".env.${environment}.dec"
-  rm -rf "ops/${deploy_file}.yaml"
 
   cat "$ENV_FILE" | base64 > "$ENCRYPTED_ENV_FILE"
   cat "$ENCRYPTED_ENV_FILE" | base64 -d > "$DECRYPTED_ENV_FILE"
 
   HELM_EXTRA_ARGS="--values ops/${deploy_file}.yaml"
-  # DEPLOY_TAG= <-------------------------------------- SET ME
+  # DEPLOY_TAG= <------------------------------- SET DEPLOY TAG
+  # DRY_RUN_DEBUG="--dry-run --debug" <--------- UNCOMMENT TO ENABLE
 else
   # FOR GitHub ACTIONS DEPLOY
   # Set ENCRYPTED_ENV_FILE in GitHub environment variable
@@ -41,15 +39,15 @@ else
   # file to your project you can then get the ENCRYPTED_ENV_FILE
   # value by running: cat "$ENV_FILE" | base64 > "$ENCRYPTED_ENV_FILE",
   # in your terminal locally to get the value needed to set in GitHub
-  echo "$ENCRYPTED_ENV_FILE" > ".env.${environment}.enc"
-  cat "$ENCRYPTED_ENV_FILE" | base64 -d > ".env.${environment}.dec"
+  # echo "$ENCRYPTED_ENV_FILE" > ".env.${environment}.enc"
+  echo "$ENCRYPTED_ENV_FILE" | base64 -d > "$DECRYPTED_ENV_FILE"
 fi
 
 # Take the env file and export each key value pair
 # so we can use it with envsubst in our deploy
 while IFS='=' read -r key value; do
   export "$key=${value//\"/}"
-done < <(grep -v '^#' ".env.${environment}.dec")
+done < <(grep -v '^#' "$DECRYPTED_ENV_FILE")
 
 DOLLAR=$ envsubst <"ops/${deploy_file}.tmpl.yaml" >"ops/${deploy_file}.yaml"
 
@@ -57,13 +55,12 @@ helm upgrade \
     --install \
     --atomic \
     --timeout 15m0s \
-    --dry-run \
-    --debug \
     --set rails.image.repository="$DEPLOY_IMAGE" \
     --set rails.image.tag="$DEPLOY_TAG" \
     --set solr.image.repository="$SOLR_IMAGE" \
     --set solr.image.tag="$DEPLOY_TAG" \
     $HELM_EXTRA_ARGS \
+    $DRY_RUN_DEBUG \
     --namespace="$namespace" \
     --create-namespace \
     "$release_name" \

--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -19,7 +19,7 @@ ENV_FILE="./.env.${environment}"
 
 if [ ! -f "$ENV_FILE" ]; then
   touch "./.env.${environment}"
-  echo "$ENCRYPTED_ENV_FILE" | base64 -d > "./.env.${environment}"
+  echo "$ENCODED_ENV_FILE" | base64 -d > "./.env.${environment}"
 else
   HELM_EXTRA_ARGS="--values ops/${deploy_file}.yaml"
   # DEPLOY_TAG=Set_me_with_ghcr_sha

--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -20,36 +20,33 @@ ENV_FILE="./.env.${environment}"
 ENCRYPTED_ENV_FILE="./.env.${environment}.enc"
 DECRYPTED_ENV_FILE="./.env.${environment}.dec"
 
-# FOR LOCAL DEPLOY SET DEPLOY TAG
+# FOR LOCAL DEPLOY
 # run ./bin/helm_deploy RELEASE_NAME NAMESPACE
 # If we are deploying locally we will have the
-# .env.${environment} file, get this from 1Password
+# .env.${environment} file locally or in 1Password
 if [ -f "$ENV_FILE" ]; then
   # remove our previous tests
   rm -rf "./.env.${environment}.enc"
   rm -rf "./.env.${environment}.dec"
   rm -rf "ops/${deploy_file}.yaml"
 
-  # set our env file for use with the deploy
   cat "$ENV_FILE" | base64 > "$ENCRYPTED_ENV_FILE"
   cat "$ENCRYPTED_ENV_FILE" | base64 -d > "$DECRYPTED_ENV_FILE"
 
-  # set the values file
   HELM_EXTRA_ARGS="--values ops/${deploy_file}.yaml"
-  # DEPLOY_TAG= <-------- DONT FORGET TO SET ME
+  # DEPLOY_TAG= <-------------------------------------- SET ME
+else
+  # FOR GitHub ACTIONS DEPLOY
+  # Set ENCRYPTED_ENV_FILE in GitHub Environment Secret
+  # section of project repo after copying the .env.${environment}
+  # file to your project you can then get the ENCRYPTED_ENV_FILE
+  # value by running: cat "$ENV_FILE" | base64 > "$ENCRYPTED_ENV_FILE",
+  # in your terminal locally to get the value needed to set in GitHub
+  cat "$ENCRYPTED_ENV_FILE" | base64 -d > "$DECRYPTED_ENV_FILE"
 fi
-
-# FOR GitHub ACTIONS DEPLOY SET ENCRYPTED_ENV_FILE in
-# GitHub Environment Secret section of project repo after
-# copying the .env.${environment} file to your project
-# you can then get the ENCRYPTED_ENV_FILE value with a
-# cat "$ENV_FILE" | base64 > "$ENCRYPTED_ENV_FILE"
-# in your terminal locally to set in GitHub
-cat "$ENCRYPTED_ENV_FILE" | base64 -d > "$DECRYPTED_ENV_FILE"
 
 # Take the env file and export each key value pair
 # so we can use it with envsubst in our deploy
-# without this we would not be able to work
 while IFS='=' read -r key value; do
   export "$key=${value//\"/}"
 done < <(grep -v '^#' "$DECRYPTED_ENV_FILE")

--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -15,19 +15,29 @@ DEPLOY_TAG="${DEPLOY_TAG:-latest}"
 
 environment=${release_name#*-}  # Extracting the environment value after "-"
 deploy_file="${environment}-deploy"
-ENVCONFIG="./.env.${environment}"
 
-echo $KUBECONFIG_FILE | base64 -d > $KUBECONFIG;
-echo $ENVCONFIG_FILE | base64 -d > $ENVCONFIG;
+ENV_FILE="./.env.${environment}"
+ENCRYPTED_ENV_FILE="./.env.${environment}.enc"
+DECRYPTED_ENV_FILE="./.env.${environment}.dec"
 
-if [[ -n $environment ]]; then
-    DOLLAR=$ envsubst <"ops/${deploy_file}.tmpl.yaml" >"ops/${deploy_file}.yaml"
-fi
+cat "$ENV_FILE" | base64 > "$ENCRYPTED_ENV_FILE"
+cat "$ENCRYPTED_ENV_FILE" | base64 -d > "$DECRYPTED_ENV_FILE"
+
+while IFS='=' read -r key value; do
+  export "$key=${value//\"/}"
+  echo "Exported: $key=${value//\"/}"
+done < <(grep -v '^#' "$DECRYPTED_ENV_FILE")
+
+DOLLAR=$ envsubst <"ops/${deploy_file}.tmpl.yaml" >"ops/${deploy_file}.yaml"
+
+HELM_EXTRA_ARGS="--values ops/${deploy_file}.yaml"
 
 helm upgrade \
     --install \
     --atomic \
     --timeout 15m0s \
+    --dry-run \
+    --debug \
     --set rails.image.repository="$DEPLOY_IMAGE" \
     --set rails.image.tag="$DEPLOY_TAG" \
     --set solr.image.repository="$SOLR_IMAGE" \

--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -45,7 +45,7 @@ fi
 # you can then get the ENCRYPTED_ENV_FILE value with a
 # cat "$ENV_FILE" | base64 > "$ENCRYPTED_ENV_FILE"
 # in your terminal locally to set in GitHub
-echo "$ENCRYPTED_ENV_FILE" | base64 -d > "$DECRYPTED_ENV_FILE"
+cat "$ENCRYPTED_ENV_FILE" | base64 -d > "$DECRYPTED_ENV_FILE"
 
 # Take the env file and export each key value pair
 # so we can use it with envsubst in our deploy

--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -10,30 +10,51 @@ namespace="${2}"
 
 DEPLOY_IMAGE="${DEPLOY_IMAGE:-ghcr.io/scientist-softserv/arce}"
 SOLR_IMAGE="${SOLR_IMAGE:-ghcr.io/scientist-softserv/arce/solr}"
-
 DEPLOY_TAG="${DEPLOY_TAG:-latest}"
 
-environment=${release_name#*-}  # Extracting the environment value after "-"
+# Extracting the environment value after "-"
+environment=${release_name#*-}
 deploy_file="${environment}-deploy"
 
 ENV_FILE="./.env.${environment}"
 ENCRYPTED_ENV_FILE="./.env.${environment}.enc"
 DECRYPTED_ENV_FILE="./.env.${environment}.dec"
 
+# FOR LOCAL DEPLOY SET DEPLOY TAG
+# run ./bin/helm_deploy RELEASE_NAME NAMESPACE
+# If we are deploying locally we will have the
+# .env.${environment} file, get this from 1Password
 if [ -f "$ENV_FILE" ]; then
-cat "$ENV_FILE" | base64 > "$ENCRYPTED_ENV_FILE"
+  # remove our previous tests
+  rm -rf "./.env.${environment}.enc"
+  rm -rf "./.env.${environment}.dec"
+  rm -rf "ops/${deploy_file}.yaml"
+
+  # set our env file for use with the deploy
+  cat "$ENV_FILE" | base64 > "$ENCRYPTED_ENV_FILE"
+  cat "$ENCRYPTED_ENV_FILE" | base64 -d > "$DECRYPTED_ENV_FILE"
+
+  # set the values file
+  HELM_EXTRA_ARGS="--values ops/${deploy_file}.yaml"
+  # DEPLOY_TAG= <-------- DONT FORGET TO SET ME
 fi
 
-cat "$ENCRYPTED_ENV_FILE" | base64 -d > "$DECRYPTED_ENV_FILE"
+# FOR GitHub ACTIONS DEPLOY SET ENCRYPTED_ENV_FILE in
+# GitHub Environment Secret section of project repo after
+# copying the .env.${environment} file to your project
+# you can then get the ENCRYPTED_ENV_FILE value with a
+# cat "$ENV_FILE" | base64 > "$ENCRYPTED_ENV_FILE"
+# in your terminal locally to set in GitHub
+echo "$ENCRYPTED_ENV_FILE" | base64 -d > "$DECRYPTED_ENV_FILE"
 
+# Take the env file and export each key value pair
+# so we can use it with envsubst in our deploy
+# without this we would not be able to work
 while IFS='=' read -r key value; do
   export "$key=${value//\"/}"
-  echo "Exported: $key=${value//\"/}"
 done < <(grep -v '^#' "$DECRYPTED_ENV_FILE")
 
 DOLLAR=$ envsubst <"ops/${deploy_file}.tmpl.yaml" >"ops/${deploy_file}.yaml"
-
-HELM_EXTRA_ARGS="--values ops/${deploy_file}.yaml"
 
 helm upgrade \
     --install \

--- a/chart/templates/web-ing.yaml
+++ b/chart/templates/web-ing.yaml
@@ -28,7 +28,7 @@ spec:
           service:
             name: {{ printf "%s" $serviceName | trunc 63 | trimSuffix "-" }}-web
             port:
-              number: http
+              name: http
           {{- end }}
         path: /
         pathType: ImplementationSpecific

--- a/chart/templates/web-ing.yaml
+++ b/chart/templates/web-ing.yaml
@@ -1,7 +1,12 @@
 ---
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := include "app.fullname" . -}}
+{{- $beta := semverCompare "<1.19-0" (default .Capabilities.KubeVersion.Version .Values.kubeVersion) -}}
+{{- if $beta }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
 apiVersion: networking.k8s.io/v1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "app.web.name" . }}-in
@@ -16,10 +21,15 @@ spec:
     http:
       paths:
       - backend:
+          {{- if $beta }}
+          serviceName: {{ printf "%s" $serviceName | trunc 63 | trimSuffix "-" }}-web
+          servicePort: http
+          {{- else }}
           service:
             name: {{ printf "%s" $serviceName | trunc 63 | trimSuffix "-" }}-web
             port:
-              name: http
+              number: http
+          {{- end }}
         path: /
         pathType: ImplementationSpecific
   {{- end }}

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -39,7 +39,7 @@ rails:
 ingress:
   enabled: true
   hosts:
-    - staging-arce-web.notch8.cloud
+    - arce-staging.notch8.cloud
   annotations: {
     kubernetes.io/ingress.class: "nginx",
     nginx.ingress.kubernetes.io/proxy-body-size: "0",


### PR DESCRIPTION
This PR includes:
- Updates the ingress template for both version of the ingress so we can deploy to k8s v1.18 - v1.21 
- Updates the values ingress host to be the correct naming convention
- Updates the helm_deploy script to allow dynamic deploy locally or through CI bringing the envsubst locally.
- Add files that will be generated during the helm deploy that we do not want to accidentally commit to the .gitignore

In order to use this helm deploy locally you will need to ensure you have downloaded the most current version of the env file for the environment you are going to be deploying to. If you are deploying to staging, then you will need to have the .env.staging file created locally and the correct values from 1Password (or at least this is what is proposed in this PR)
