### PR TITLE
i82-brakeman-audit-fixes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,7 @@ module ApplicationHelper
     options[:field] # the field to render
     options[:value] # the value of the field
 
-    link_to options[:value].first, options[:value].first, target: '_blank'
+    link_to(options[:value].first, options[:value].first, target: "_blank", rel: "noopener noreferrer")
   end
 
   def link_to_add_gac_fields(name, form, association)

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -35,7 +35,7 @@
   <!-- Content -->
   <div class="col-md-12">
     <div class="g-mb-60">
-      <%= @collection.content.html_safe %>
+      <%= html_escape(@collection.content) %>
     </div>
   </div>
   <!-- End Content -->

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
https://github.com/scientist-softserv/arce/issues/82

Fixes the following brakeman audit line items:
Confidence: High
Category: Cross-Site Scripting
Check: CrossSiteScripting
Message: Unescaped model attribute
Code: Collection.new(collection_params).content
File: app/views/collections/show.html.erb
Line: 38

Confidence: High
Category: Missing Encryption
Check: ForceSSL
Message: The application does not force use of HTTPS: config.force_ssl is not enabled
File: config/environments/production.rb
Line: 1

Confidence: Medium
Category: Reverse Tabnabbing
Check: ReverseTabnabbing
Message: When opening a link in a new tab without setting rel: "noopener noreferrer", the new tab can control the parent tab's location. For example, an attacker could redirect to a phishing page.
Code: link_to(options[:value].first, options[:value].first, :target => "_blank")
File: app/helpers/application_helper.rb
Line: 21