### PR TITLE
i760-devops-node-affinity

### DIFF
--- a/chart/templates/solr-deploy.yaml
+++ b/chart/templates/solr-deploy.yaml
@@ -26,6 +26,10 @@ spec:
         checksum/rails-env-cm: {{ include (print $.Template.BasePath "/rails-env-cm.yaml") . | sha256sum }}
         checksum/rails-env-secret: {{ include (print $.Template.BasePath "/rails-env-secret.yaml") . | sha256sum }}
     spec:
+      {{- with .Values.solr.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Always
       {{- if .Values.solr.imagePullSecrets }}
       imagePullSecrets:

--- a/chart/templates/web-deploy.yaml
+++ b/chart/templates/web-deploy.yaml
@@ -26,6 +26,10 @@ spec:
         checksum/rails-env-cm: {{ include (print $.Template.BasePath "/rails-env-cm.yaml") . | sha256sum }}
         checksum/rails-env-secret: {{ include (print $.Template.BasePath "/rails-env-secret.yaml") . | sha256sum }}
     spec:
+      {{- with .Values.web.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Always
       {{- if .Values.rails.imagePullSecrets }}
       imagePullSecrets:

--- a/chart/templates/worker-deploy.yaml
+++ b/chart/templates/worker-deploy.yaml
@@ -26,6 +26,10 @@ spec:
         checksum/rails-env-cm: {{ include (print $.Template.BasePath "/rails-env-cm.yaml") . | sha256sum }}
         checksum/rails-env-secret: {{ include (print $.Template.BasePath "/rails-env-secret.yaml") . | sha256sum }}
     spec:
+      {{- with .Values.worker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Always
       {{- if .Values.rails.imagePullSecrets }}
       imagePullSecrets:

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -1,4 +1,14 @@
 web:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: name
+            operator: In
+            values:
+              - {{ template "app.web.name" . }}
+        topologyKey: "kubernetes.io/hostname"
   replicas: 2
   resources:
     limits:
@@ -9,6 +19,16 @@ web:
       cpu: "200m"
 
 worker:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: name
+            operator: In
+            values:
+              - {{ template "app.worker.name" . }}
+        topologyKey: "kubernetes.io/hostname"
   replicas: 1
   resources:
     limits:
@@ -19,6 +39,16 @@ worker:
       cpu: "50m"
 
 solr:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: name
+            operator: In
+            values:
+              - {{ template "app.solr.name" . }}
+        topologyKey: "kubernetes.io/hostname"
   replicas: 1
   resources:
     limits:

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -1,4 +1,14 @@
 solr:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: name
+            operator: In
+            values:
+              - {{ template "app.solr.name" . }}
+        topologyKey: "kubernetes.io/hostname"
   image:
     repository: ghcr.io/scientist-softserv/arce/solr
     tag: latest
@@ -19,9 +29,29 @@ postgresql:
     size: 1Gi
 
 web:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: name
+            operator: In
+            values:
+              - {{ template "app.web.name" . }}
+        topologyKey: "kubernetes.io/hostname"
   replicas: 2
 
 worker:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: name
+            operator: In
+            values:
+              - {{ template "app.worker.name" . }}
+        topologyKey: "kubernetes.io/hostname"
   replicas: 1
 
 rails:


### PR DESCRIPTION
# Story
As a node goes down and the workloads are dumped onto other nodes, this will guarantee that the when there are 2 or more web pods and 2 or more worker pods they will not be spun up on the same node. (Note a worker and web pod CAN spin up on the same node, but no more than 1 worker or web pod will ever exist on the same node together)

- https://github.com/scientist-softserv/dev-ops/issues/760

# Expected Behavior Before Changes
When a node goes down a web or worker pods can then get dumped onto a node that already has a web or worker pods for that project causing additional increased load and increase additional node outages without manual intervention by redeploying the projects workload that is effected.

# Expected Behavior After Changes
When a node goes down the web or worker pods for that project will never exist on the same node.

# Notes
Glass Canvas has this implementation currently and we have modeled ours after this, but instead of using the item key par, we have used name, since the charts we inherit form hyrax do not contain that key value pair. https://github.com/glass-canvas/tilma/blob/53942b869ea38211c24abc4f176c2113b37bd0ea/chart/templates/rails-deploy.yaml#L36